### PR TITLE
Add wrapper for new Grid module

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -1,0 +1,1 @@
+module.exports = require('material-ui/Grid');


### PR DESCRIPTION
Material-ui-next changed the name of the "Layout" component to "Grid". This breaks the wrapper project for material-ui-next. We added a Grid component so it will continue to work.

Thank you for making this, as we are using it for an application we are building!